### PR TITLE
Fixes 2022-03-07

### DIFF
--- a/includes/SyntaxHighlight.php
+++ b/includes/SyntaxHighlight.php
@@ -99,7 +99,8 @@ class SyntaxHighlight {
         $code = trim($code);
 
         $codeTagAttrs = array(
-            'class' => 'mw-syntaxhighlight-code language-' . $lang
+            'class' => 'mw-syntaxhighlight-code language-' . $lang,
+            'dir' => 'ltr'
         );
         if ($inline) {
             $codeTagAttrs['class'] .= ' mw-syntaxhighlight-inline';
@@ -113,7 +114,8 @@ class SyntaxHighlight {
 
         if (!$inline) {
             $preTagAttrs = array(
-                'class' => 'mw-syntaxhighlight ' . ($showLineNum ? 'line-numbers' : 'no-line-numbers')
+                'class' => 'mw-syntaxhighlight ' . ($showLineNum ? 'line-numbers' : 'no-line-numbers'),
+                'dir' => 'ltr'
             );
             if ($highlight) {
                 $preTagAttrs['data-line'] = $highlight;

--- a/resources/syntaxhighlight-core.css
+++ b/resources/syntaxhighlight-core.css
@@ -1,4 +1,5 @@
 pre.mw-syntaxhighlight > code.mw-syntaxhighlight-code {
   border-radius: unset;
   border: unset;
+  padding: unset;
 }


### PR DESCRIPTION
* Removed this annoying space at the start of code:
![image](https://user-images.githubusercontent.com/28599280/157147434-c9dcb181-b4c2-42cf-a175-62fc0c0470a6.png)
* Added `dir="ltr"` attribute to generated `pre` and `code` elements (resolves #1)