### PR TITLE
Use @noflip in a comment to prevent text-align: left from changing

### DIFF
--- a/resources/prism.css
+++ b/resources/prism.css
@@ -4,6 +4,7 @@
  * @author Lea Verou
  */
 
+/* @noflip */
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;


### PR DESCRIPTION
to right with RTL languages.

https://www.mediawiki.org/wiki/ResourceLoader/Architecture#Flipping