### PR TITLE
Replace labelMsg with label: mw.message()

### DIFF
--- a/resources/syntaxhighlight-wikieditor.js
+++ b/resources/syntaxhighlight-wikieditor.js
@@ -4,7 +4,7 @@ mw.hook('wikiEditor.toolbarReady').add(function ($textarea) {
         group: 'insert',
         tools: {
             smile: {
-                labelMsg: 'syntaxhighlight-wikieditor-button',
+                label: mw.message( 'syntaxhighlight-wikieditor-button' ).text(),
                 type: 'button',
                 oouiIcon: 'code',
                 action: {


### PR DESCRIPTION
The autoMsg function in WikiEditor is about to be deprecated in favour of using mw.message() directly like this.